### PR TITLE
Add email auth

### DIFF
--- a/backend/paran/build.gradle
+++ b/backend/paran/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.apache.tomcat.embed:tomcat-embed-jasper'

--- a/backend/paran/src/main/java/ari/paran/Util/SecurityUtil.java
+++ b/backend/paran/src/main/java/ari/paran/Util/SecurityUtil.java
@@ -15,6 +15,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 
 import java.util.Optional;
+import java.util.Random;
+
 @Slf4j
 public class SecurityUtil {
 
@@ -38,6 +40,20 @@ public class SecurityUtil {
         }
 
         return Long.parseLong(username);
+    }
+
+    public static String generateCode() {
+        Random random = new Random();
+        String code = "";
+
+        for(int i = 0;i<3;i++){
+            int index = random.nextInt(25)+65;
+            code+=(char)index;
+        }
+        int numIndex = random.nextInt(9999)+1000;
+        code +=numIndex;
+
+        return code;
     }
 
 }

--- a/backend/paran/src/main/java/ari/paran/config/EmailConfig.java
+++ b/backend/paran/src/main/java/ari/paran/config/EmailConfig.java
@@ -1,0 +1,56 @@
+package ari.paran.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+import java.util.Properties;
+
+
+@Configuration
+@PropertySource("classpath:application-mail.properties")
+public class EmailConfig {
+
+    @Value("${mail.smtp.port}")
+    private int port;
+    @Value("${mail.smtp.socketFactory.port}")
+    private int socketPort;
+    @Value("${mail.smtp.auth}")
+    private boolean auth;
+    @Value("${mail.smtp.starttls.enable}")
+    private boolean starttls;
+    @Value("${mail.smtp.starttls.required}")
+    private boolean startlls_required;
+    @Value("${mail.smtp.socketFactory.fallback}")
+    private boolean fallback;
+    @Value("${AdminMail.id}")
+    private String id;
+    @Value("${AdminMail.password}")
+    private String password;
+
+    @Bean
+    public JavaMailSender javaMailService() {
+        JavaMailSenderImpl javaMailSender = new JavaMailSenderImpl();
+        javaMailSender.setHost("smtp.gmail.com");
+        javaMailSender.setUsername(id);
+        javaMailSender.setPassword(password);
+        javaMailSender.setPort(port);
+        javaMailSender.setJavaMailProperties(getMailProperties());
+        javaMailSender.setDefaultEncoding("UTF-8");
+        return javaMailSender;
+    }
+    private Properties getMailProperties()
+    {
+        Properties pt = new Properties();
+        pt.put("mail.smtp.socketFactory.port", socketPort);
+        pt.put("mail.smtp.auth", auth);
+        pt.put("mail.smtp.starttls.enable", starttls);
+        pt.put("mail.smtp.starttls.required", startlls_required);
+        pt.put("mail.smtp.socketFactory.fallback",fallback);
+        pt.put("mail.smtp.socketFactory.class", "javax.net.ssl.SSLSocketFactory");
+        return pt;
+    }
+}

--- a/backend/paran/src/main/java/ari/paran/controller/JwtController.java
+++ b/backend/paran/src/main/java/ari/paran/controller/JwtController.java
@@ -14,6 +14,8 @@ import org.springframework.validation.Errors;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/auth")
@@ -24,7 +26,7 @@ public class JwtController {
     private final MemberService memberService;
     private final Response response;
 
-    @PostMapping("/signup/user")
+    @PostMapping("/signup-user")
     public ResponseEntity<?> signupUser(@RequestBody SignupDto signupDto, Errors errors) {
         //validation check
         if (errors.hasErrors()) {
@@ -33,13 +35,25 @@ public class JwtController {
         return memberService.signupUser(signupDto);
     }
 
-    @PostMapping("/signup/owner")
+    @PostMapping("/signup-owner")
     public ResponseEntity<?> signupOwner(@RequestBody SignupDto signupDto, Errors errors) {
         //validation check
         if (errors.hasErrors()) {
             return response.invalidFields(Helper.refineErrors(errors));
         }
         return memberService.signupOwner(signupDto);
+    }
+
+    @PostMapping("/email")
+    public ResponseEntity<?> sendEmail(@RequestBody Map<String, String> param) {
+        String email = param.get("email");
+        return memberService.sendEmail(email);
+    }
+
+    @PostMapping("email-auth")
+    public ResponseEntity<?> authEmail(@RequestBody Map<String, String> param) {
+        String code = param.get("code");
+        return memberService.authEmail(code);
     }
 
     @PostMapping("/login")

--- a/backend/paran/src/main/resources/application-mail.properties
+++ b/backend/paran/src/main/resources/application-mail.properties
@@ -1,0 +1,12 @@
+#?? ?? ?? ??
+mail.smtp.auth=true
+mail.smtp.starttls.required=true
+mail.smtp.starttls.enable=true
+mail.smtp.socketFactory.class=javax.net.ssl.SSLSocketFactory
+mail.smtp.socketFactory.fallback=false
+mail.smtp.port=465
+mail.smtp.socketFactory.port=465
+
+#admin ?? ??
+AdminMail.id = aritest0222@gmail.com
+AdminMail.password = pbexaylkmszrnxvi


### PR DESCRIPTION
이메일 인증 기능 추가 했습니다.

이메일을 입력하고 json에 {"email":"입력한 이메일"} 담아 /auth/email로 post요청 보내면 7자리 코드가 전송됩니다.

5분안에 해당 코드를 입력하고 json에 {"code":"입력한 코드"} 담아 /auth/email-auth로 post요청 보내면 일치할 경우 200, 이외의 경우에는 400을 응답합니다.